### PR TITLE
Relax header checks

### DIFF
--- a/lib/reqhandler.js
+++ b/lib/reqhandler.js
@@ -31,10 +31,15 @@ function checkRequest(req, path) {
     err = { statusCode: 404 };
   } else if (req.method !== 'POST') {
     err = { statusCode: 405 };
-  } else if (req.headers['content-type'] !== 'application/json') {
+  } else if (!req.headers['content-type'] || (req.headers['content-type'] !== 'application/json' &&
+    !req.headers['content-type'].startsWith('application/json;'))) {
     err = { statusCode: 415 };
-  } else if (req.headers.accept !== 'application/json') {
-    err = { statusCode: 400, message: 'Accept header must be application/json' };
+  } else if (!req.headers.accept || (req.headers.accept !== 'application/json' &&
+    !req.headers.accept.split(',').some((value) => {
+      const trimmedValue = value.trim();
+      return trimmedValue === 'application/json' || trimmedValue.startsWith('application/json;');
+    }))) {
+    err = { statusCode: 400, message: 'Accept header must include application/json' };
   } else if (!('content-length' in req.headers)) {
     err = { statusCode: 400, message: 'Missing Content-Length header' };
   } else {


### PR DESCRIPTION
This relaxes the checks for Content-Type and Accept headers to allow charsets to be defined in the Content-Type and to allow multiple Accept types as long as one is `application/json`.

Closes #1.