### PR TITLE
Optional this context for methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,25 @@
 [![dependencies Status](https://david-dm.org/sangaman/http-jsonrpc-server/status.svg)](https://david-dm.org/sangaman/http-jsonrpc-server)
 [![devDependencies Status](https://david-dm.org/sangaman/http-jsonrpc-server/dev-status.svg)](https://david-dm.org/sangaman/http-jsonrpc-server?type=dev)
 
-- [Install](#install)
-- [Usage](#usage)
-  - [Specifying a Path](#specifying-a-path)
-  - [Optional Callbacks](#optional-callbacks)
-  - [Adding/Updating Methods](#adding-updating-methods)
-  - [Closing the Server](#closing-the-server)
-  - [Native HTTP Server](#native-http-server)
-  - [Exposed Constants](#exposed-constants)
-- [API Documentation](#api-documentation)
-- [Sample Requests](#sample-requests)
-  - [Sum](#sum)
-  - [Sum (Batched)](#sum--batched-)
-  - [Wait](#wait)
+- [http-jsonrpc-server](#http-jsonrpc-server)
+  - [Install](#install)
+  - [Usage](#usage)
+    - [Specifying a Path](#specifying-a-path)
+    - [Optional Callbacks](#optional-callbacks)
+    - [Adding/Updating Methods](#addingupdating-methods)
+    - [Closing the Server](#closing-the-server)
+    - [Native HTTP Server](#native-http-server)
+    - [Exposed Constants](#exposed-constants)
+  - [API Documentation](#api-documentation)
+  - [RpcServer](#rpcserver)
+    - [new RpcServer(options)](#new-rpcserveroptions)
+    - [rpcServer.setMethod(name, method)](#rpcserversetmethodname-method)
+    - [rpcServer.listen(port, host) ⇒ <code>Promise</code>](#rpcserverlistenport-host--codepromisecode)
+    - [rpcServer.close() ⇒ <code>Promise</code>](#rpcserverclose--codepromisecode)
+  - [Sample Requests](#sample-requests)
+    - [Sum](#sum)
+    - [Sum (Batched)](#sum-batched)
+    - [Wait](#wait)
 
 A simple and lightweight library for creating a JSON-RPC 2.0 compliant HTTP server.
 
@@ -163,6 +169,7 @@ Create an RpcServer
 | --- | --- | --- |
 | options | <code>Object</code> | Optional parameters for the server. |
 | options.methods | <code>Object</code> | A map of method names to functions. Method functions are passed one parameter which will either be an Object or a string array. |
+| options.context |  | Context to be used as `this` for method functions. |
 | options.path | <code>string</code> | The path for the server. |
 | options.onRequest | <code>function</code> | Callback for when requests are received, it is passed an Object representing the request. |
 | options.onRequestError | <code>function</code> | Callback for when requested methods throw errors, it is passed an error and request id. |

--- a/lib/http-jsonrpc-server.js
+++ b/lib/http-jsonrpc-server.js
@@ -12,6 +12,7 @@ class RpcServer {
    * @param {Object} options - Optional parameters for the server.
    * @param {Object} options.methods - A map of method names to functions. Method functions are
    * passed one parameter which will either be an Object or a string array.
+   * @param options.context - Context to be used as `this` for method functions.
    * @param {string} options.path - The path for the server.
    * @param {function} options.onRequest - Callback for when requests are received, it is
    * passed an Object representing the request.
@@ -48,6 +49,12 @@ class RpcServer {
         assert(typeof options.methods[key] === 'function', 'methods may only contain functions');
       }
       this.methods = options.methods;
+      if (options.context) {
+        for (let n = 0; n < keys.length; n += 1) {
+          const key = keys[n];
+          this.methods[key] = this.methods[key].bind(options.context);
+        }
+      }
     }
     if (options.path) {
       assert(typeof options.path === 'string', 'path must be a string');

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,10 @@ async function wait(params) {
   });
 }
 
+function getContext() {
+  return this;
+}
+
 const testPath = '/testpath';
 
 describe('constructor', () => {
@@ -122,7 +126,9 @@ describe('handling requests', () => {
     methods: {
       sum,
       wait,
+      getContext,
     },
+    context: 'test context',
   });
 
   it('should 404 an unknown path', () => request(rpcServer.server)
@@ -246,6 +252,13 @@ describe('handling requests', () => {
     body: '{"jsonrpc":"2.0","id":7,"method":"wait","params":{"ms":50}}',
   }).then((response) => {
     assertResult(response.body, true, 7);
+  }));
+
+  it('should use optional context as this', () => testRequest({
+    server: rpcServer.server,
+    body: '{"jsonrpc":"2.0","id":16,"method":"getContext"}',
+  }).then((response) => {
+    assertResult(response.body, 'test context', 16);
   }));
 });
 


### PR DESCRIPTION
This adds an option to specify a context to be used for `this` within any methods that refer to `this`. This prevents people using the library from having to manually bind methods.