### PR TITLE
Properly remove listeners on listen & close

### DIFF
--- a/lib/http-jsonrpc-server.js
+++ b/lib/http-jsonrpc-server.js
@@ -116,11 +116,14 @@ class RpcServer {
    */
   listen(port, host) {
     return new Promise((resolve, reject) => {
+      const errHandler = (err) => {
+        reject(err);
+      };
+
       this.server.listen(port, host, () => {
         resolve(this.server.address().port);
-      }).once('error', (err) => {
-        reject(err);
-      });
+        this.server.removeListener('error', errHandler);
+      }).once('error', errHandler);
     });
   }
 
@@ -133,6 +136,7 @@ class RpcServer {
     return new Promise((resolve, reject) => {
       this.server.close(() => {
         resolve(true);
+        this.server.removeAllListeners();
       }).once('error', (err) => {
         reject(err);
       });

--- a/test/test.js
+++ b/test/test.js
@@ -367,4 +367,15 @@ describe('listening and closing', () => {
     }
     assert(!rpcServer.server.listening);
   });
+
+  it('should not leave listeners on closed servers', async () => {
+    // treat erroring to console as a failure
+    // this will fail on the "(node:7268) MaxListenersExceededWarning" error
+    console.error = assert.fail;
+
+    for (let n = 0; n < 11; n += 1) {
+      await rpcServer.listen();
+      await rpcServer.close();
+    }
+  });
 });


### PR DESCRIPTION
This fixes a bug where listeners were being added to the server object but never removed. Listening and closing on a server multiple times would result in a warning console message.

Fixes #3.