### PR TITLE
Add Basic Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - [Optional Callbacks](#optional-callbacks)
     - [Adding/Updating Methods](#addingupdating-methods)
     - [Closing the Server](#closing-the-server)
+    - [Basic Authentication](#basic-authentication)
     - [Native HTTP Server](#native-http-server)
     - [Exposed Constants](#exposed-constants)
   - [API Documentation](#api-documentation)
@@ -109,7 +110,7 @@ const rpcServer = new RpcServer({
 
 ### Adding/Updating Methods
 
-You can register new methods or updates existing ones after the server has been created.
+You can register new methods or update existing ones after the server has been created.
 
 ```javascript
 rpcServer.setMethod('sum', sum);
@@ -121,6 +122,18 @@ rpcServer.setMethod('sum', sum);
 rpcServer.close().then(() => {
   console.log('server stopped listening');
 }
+```
+
+### Basic Authentication
+
+You can optionally enable [Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) by specifying credentials when creating the server. Any requests will then require an `Authorization` header with `[username]:[password]` encoded in Base64. Note that TLS is not currently supported, therefore all traffic is unencrypted and these credentials can be stolen by anyone relaying or listening to requests. This authentication alone should not be considered secure over public networks.
+
+```javascript
+const rpcServer = new RpcServer({
+  username: 'johndoe',
+  password: 'wasspord', // ignored unless username is specified
+  realm: 'rpc' // realm defaults to "Restricted" if not specified
+});
 ```
 
 ### Native HTTP Server
@@ -173,6 +186,9 @@ Class representing a HTTP JSON-RPC server
 | options.onRequestError | <code>function</code> | Callback for when requested methods throw errors, it is passed an error and request id |
 | options.onResult | <code>function</code> | Callback for when requests are successfully returned a result. It is passed the response object and request id |
 | options.onServerError | <code>function</code> | Callback for server errors, it is passed an [Error](https://nodejs.org/api/errors.html#errors_class_error) |
+| options.username | <code>string</code> | Username for authentication. If provided, Basic Authentication will be enabled and required for all requests. |
+| options.password | <code>string</code> | Password for authentication, ignored unless a username is also specified. |
+| options.realm | <code>string</code> | Realm for authentication, ignored unless a username is also specified, defaults to `Restricted` if not specified. |
 
 <a name="RpcServer+setMethod"></a>
 

--- a/lib/http-jsonrpc-server.d.ts
+++ b/lib/http-jsonrpc-server.d.ts
@@ -17,6 +17,18 @@ declare class RpcServer {
     onResult: (response: any, id: string) => void,
     /** Callback for server errors. */
     onServerError: (err: Error) => void,
+    /**
+     * Username for authentication. If provided, Basic Authentication will be enabled and required
+     * for all requests.
+     */
+    username: string,
+    /** Password for authentication, ignored unless a username is also specified. */
+    password: string,
+    /**
+     * Realm for authentication, ignored unless a username is also specified, defaults to
+     * `Restricted` if not specified.
+     */
+    realm: string,
   });
 
   /** 

--- a/lib/http-jsonrpc-server.js
+++ b/lib/http-jsonrpc-server.js
@@ -21,14 +21,17 @@ class RpcServer {
    * result. It is passed the response object and request id
    * @param {function} options.onServerError - Callback for server errors, it is passed an
    * {@link https://nodejs.org/api/errors.html#errors_class_error Error}
+   * @param {string} options.username - Username for authentication. If provided, Basic
+   * Authentication will be enabled and required for all requests.
+   * @param {string} options.password - Password for authentication, ignored unless a username is
+   * also specified.
+   * @param {string} options.realm - Realm for authentication, ignored unless a username is also
+   * specified, defaults to `Restricted` if not specified.
    */
   constructor(options) {
     this.methods = {};
     this.path = '/';
-    this.onRequest = null;
-    this.onRequestError = null;
-    this.onResult = null;
-    this.onServerError = null;
+
     if (options) {
       this.applyOptions(options);
     }
@@ -55,12 +58,26 @@ class RpcServer {
         }
       }
     }
+
     if (options.path) {
       assert(typeof options.path === 'string', 'path must be a string');
       assert(options.path.startsWith('/'), 'path must start with a "/" slash');
       assert(/^[A-Za-z0-9\-./\]@$&()*+,;=`_:~?#!']+$/.test(options.path), 'path contains invalid characters');
       this.path = options.path;
     }
+
+    if (options.username) {
+      // Basic Authentication is enabled
+      assert(typeof options.username === 'string', 'username must be a string');
+      let stringToEncode = `${options.username}:`;
+      if (options.password) {
+        assert(typeof options.password === 'string', 'password must be a string');
+        stringToEncode += options.password;
+      }
+      this.authorization = Buffer.from(stringToEncode).toString('base64');
+      this.realm = options.realm || 'Restricted';
+    }
+
     callbackNames.forEach((callbackName) => {
       if (options[callbackName]) {
         assert(typeof options[callbackName] === 'function', `${callbackName} must be a function`);

--- a/lib/reqhandler.js
+++ b/lib/reqhandler.js
@@ -57,6 +57,15 @@ function reqHandler(req, res) {
     return;
   }
 
+  if (this.authorization) {
+    const { authorization } = req.headers;
+    if (!authorization || !authorization.startsWith('Basic ') || authorization.substring(6) !== this.authorization) {
+      res.setHeader('WWW-Authenticate', `Basic realm="${this.realm}"`);
+      sendError(res, 401);
+      return;
+    }
+  }
+
   const body = [];
   req.on('data', (chunk) => {
     body.push(chunk);


### PR DESCRIPTION
This adds an option to enable Basic Authentication on all requests.

Closes #6.

@aitoribanez Take a look if you'd like and let me know if this provides the functionality you were looking for. It only supports one set of credentials currently.