### PR TITLE
Fix Content-Length for responses containing non-single-byte charac…

### DIFF
--- a/lib/reqhandler.js
+++ b/lib/reqhandler.js
@@ -73,7 +73,7 @@ function reqHandler(req, res) {
     const bodyStr = Buffer.concat(body).toString();
     const reqContentLength = parseInt(req.headers['content-length'], 10);
 
-    if (bodyStr.length !== reqContentLength) {
+    if (Buffer.byteLength(bodyStr) !== reqContentLength) {
       sendError(res, 400, consts.INVALID_CONTENT_LENGTH_MSG);
       return;
     }

--- a/lib/reqhandler.js
+++ b/lib/reqhandler.js
@@ -4,7 +4,7 @@ function sendResponse(res, response) {
   if (response) {
     const responseStr = JSON.stringify(response);
     res.setHeader('Content-Type', 'application/json');
-    res.setHeader('Content-Length', responseStr.length);
+    res.setHeader('Content-Length', Buffer.byteLength(responseStr));
     res.write(responseStr);
   } else {
     // Respond 204 for notifications with no response
@@ -19,7 +19,7 @@ function sendError(res, statusCode, message) {
   if (message) {
     const formattedMessage = `{"error":"${message}"}`;
     res.setHeader('Content-Type', 'application/json');
-    res.setHeader('Content-Length', formattedMessage.length);
+    res.setHeader('Content-Length', Buffer.byteLength(formattedMessage));
     res.write(formattedMessage);
   }
   res.end();


### PR DESCRIPTION
From the NodeJS docs:
Content-Length is given in bytes not characters. (...) If the body contains higher coded characters then Buffer.byteLength() should be used to determine the number of bytes in a given encoding.