### PR TITLE
Fix null/zero id bug

### DIFF
--- a/lib/http-jsonrpc-server.js
+++ b/lib/http-jsonrpc-server.js
@@ -163,62 +163,66 @@ class RpcServer {
     if (this.onRequest) {
       this.onRequest(request);
     }
-    let response = {
+    const response = {
       jsonrpc: '2.0',
     };
 
-    if (request.id) {
-      if (request.id !== null && typeof request.id !== 'number' && typeof request.id !== 'string') {
+    if (request.id !== undefined) {
+      if (typeof request.id !== 'number' && typeof request.id !== 'string' && request.id !== null) {
         response.error = {
           code: consts.INVALID_REQUEST,
           message: 'Invalid id',
+          id: null,
         };
         return response;
       }
       response.id = request.id;
     }
-
     if (request.jsonrpc !== '2.0') {
       response.error = {
         code: consts.INVALID_REQUEST,
         message: 'Invalid jsonrpc value',
       };
-    } else if (!request.id) {
-      // if we have no id, treat this as a notification and return nothing
-      response = undefined;
-    } else if (!request.method || typeof request.method !== 'string' || request.method.startsWith('rpc.') || !(request.method in this.methods)) {
+      return response;
+    }
+    if (!request.method || typeof request.method !== 'string' || request.method.startsWith('rpc.') || !(request.method in this.methods)) {
       response.error = {
         code: consts.METHOD_NOT_FOUND,
       };
-    } else if (request.params && typeof request.params !== 'object') {
+      return response;
+    } if (request.params && typeof request.params !== 'object') {
       response.error = {
         code: consts.INVALID_PARAMS,
       };
-    } else {
-      // we have passed all up front error checks, call the method
-      try {
-        response.result = await Promise.resolve(this.methods[request.method](request.params));
-        if (!response.id) {
-          response = undefined; // don't return a response if id is null
-        }
-      } catch (err) {
-        if (this.onRequestError) {
-          this.onRequestError(err, request.id);
-        }
-        const message = err.message || err;
-        response.error = { message };
-        if (err.code && err.code <= consts.SERVER_ERROR && err.code >= consts.SERVER_ERROR_MAX) {
-          response.error.code = err.code;
-        } else {
-          response.error.code = consts.SERVER_ERROR;
-        }
+      return response;
+    }
+
+    // we have passed all up front error checks, call the method
+    try {
+      response.result = await Promise.resolve(this.methods[request.method](request.params));
+    } catch (err) {
+      if (this.onRequestError) {
+        this.onRequestError(err, request.id);
+      }
+      const message = err.message || err;
+      response.error = { message };
+      if (err.code && err.code <= consts.SERVER_ERROR && err.code >= consts.SERVER_ERROR_MAX) {
+        response.error.code = err.code;
+      } else {
+        response.error.code = consts.SERVER_ERROR;
       }
     }
 
-    if (this.onResult && response.result) {
-      this.onResult(response.result, request.id);
+    if (response.id !== undefined) {
+      // if we have an id, we respond with the result from calling the method
+      if (this.onResult && response.result) {
+        this.onResult(response.result, request.id);
+      }
+      return response;
     }
-    return response;
+
+    // if we have no id, treat this as a notification and return nothing
+    return undefined;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "lib/http-jsonrpc-server.d.ts",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "lint": "./node_modules/.bin/eslint . ./**/*.js",
+    "lint": "eslint . ./**/*.js",
     "test": "nyc mocha"
   },
   "repository": {


### PR DESCRIPTION
This fixes a bug where falsey `id` values would be incorrectly ignored
and treated as notifications.

The JSON-RPC 2.0 spec allows any `number`, `string`, or `null` `id` as
valid, including falsey values like zero or an empty string. This `id`
must be included in the response.

Tests are added to cover this and other test cases around the `id` value.

Fixes #19.